### PR TITLE
.using() docstring incorrect

### DIFF
--- a/beanstalkc.py
+++ b/beanstalkc.py
@@ -179,7 +179,7 @@ class Connection(object):
         return self._interact_yaml('list-tubes\r\n', ['OK'])
 
     def using(self):
-        """Return a list of all tubes currently being used."""
+        """Return the tube currently being used."""
         return self._interact_value('list-tube-used\r\n', ['USING'])
 
     def use(self, name):


### PR DESCRIPTION
Just a little thing that tripped me up today.

Docstring implies the return value will be a list when the return value is a string.

[Beanstalk Protocol](https://github.com/kr/beanstalkd/blob/master/doc/protocol.txt#L659)
