### PR TITLE
Updates TUTORIAL.mkvd - Default value for connect_timeout

### DIFF
--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -26,7 +26,8 @@ If we leave out the `host` and/or `port` parameters, `'localhost'` and `11300`
 would be used as defaults, respectively. There is also a `connect_timeout`
 parameter which determines how long, in seconds, the socket will wait for the
 server to respond to its initial connection attempt. If it is `None`, then
-there will be no timeout; it defaults to 1.
+there will be no timeout; it defaults to the result of your systems
+`socket.getdefaulttimeout()`.
 
 
 Basic Operation


### PR DESCRIPTION
Current tutorial states default value for `connect_timeout` is 1. Default is actually whatever is returned from `socket.getdefaulttimeout()`. Which can be None.
