### PR TITLE
Wrapped _socket.close in its own try-except.

### DIFF
--- a/beanstalkc.py
+++ b/beanstalkc.py
@@ -70,6 +70,9 @@ class Connection(object):
         """Close connection to server."""
         try:
             self._socket.sendall('quit\r\n')
+        except socket.error:
+            pass
+        try:
             self._socket.close()
         except socket.error:
             pass


### PR DESCRIPTION
Fixes the bug described in Issue #34 in beanstalkc:
https://github.com/earl/beanstalkc/issues/34
