### PR TITLE
Added a small YAML parser, which should be sufficient for most purposes.

### DIFF
--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -447,8 +447,9 @@ extension.
 [PyYAML]: http://pyyaml.org/
 [libyaml]: http://pyyaml.org/wiki/LibYAML
 
-If, for whatever reason, you cannot use PyYAML, you can still use beanstalkc
-and just leave the YAML responses unparsed. To do that, pass `parse_yaml=False`
+If, for whatever reason, you cannot use PyYAML, you can still use beanstalkc.
+beanstalkc includes a limited parser which may suit your needs, or you can
+just leave the YAML responses unparsed. To do that, pass `parse_yaml=False`
 when creating the `Connection`:
 
     >>> beanstalk = beanstalkc.Connection(host='localhost',
@@ -482,3 +483,8 @@ Alternatively, you can also pass a function to be used as YAML parser:
     >>> beanstalk.close()
 
 This should come in handy if PyYAML simply does not fit your needs.
+
+The output of the builtin parser is mostly identical to PyYAML for the
+data returned by beanstalkd. The known difference is that all non-integer
+values are left as strings. This affects a limited set of keys in the
+stats() response.


### PR DESCRIPTION
If parse_yaml is True and PyYAML is not available, this change fails over to a small built-in parser which handles the syntax returned by beanstalkd. For example:

```
>>> import beanstalkc
>>> import pprint
>>> bs = beanstalkc.Connection()
>>> pprint(bs.stats())
{'binlog-current-index': 0,
 'binlog-max-size': 10485760,
 ...
 'current-jobs-buried': 0,
 'current-jobs-delayed': 0,
 'current-jobs-ready': 0,
 'current-jobs-reserved': 0,
 ...
 'rusage-stime': '0.008396',
 'rusage-utime': '0.000000',
 ...
 'version': '1.9'}
>>> bs.use('t1')
't1'
>>> bs.watch('t1')
2
>>> bs.using()
't1'
>>> bs.watching()
['default', 't1']
>>> bs.put('a job for t1', priority = 56)
6
>>> j = bs.reserve()
>>> pprint(j.stats())
{'age': 9,
 'buries': 0,
 'delay': 0,
 'file': 0,
 'id': 6,
 'kicks': 0,
 'pri': 56,
 'releases': 0,
 'reserves': 1,
 'state': 'reserved',
 'time-left': 118,
 'timeouts': 0,
 'ttr': 120,
 'tube': 't1'}
>>> j.release()
>>> j = bs.reserve()
>>> pprint(j.stats())
{'age': 68,
 'buries': 0,
 'delay': 0,
 'file': 0,
 'id': 6,
 'kicks': 0,
 'pri': 56,
 'releases': 1,
 'reserves': 2,
 'state': 'reserved',
 'time-left': 115,
 'timeouts': 0,
 'ttr': 120,
 'tube': 't1'}
>>> pprint(bs.stats_tube('t1'))
{'cmd-delete': 1,
 'cmd-pause-tube': 0,
 'current-jobs-buried': 0,
 'current-jobs-delayed': 0,
 'current-jobs-ready': 0,
 'current-jobs-reserved': 1,
 'current-jobs-urgent': 0,
 'current-using': 1,
 'current-waiting': 0,
 'current-watching': 1,
 'name': 't1',
 'pause': 0,
 'pause-time-left': 0,
 'total-jobs': 2}
>>> for i in range(1,bs.stats()['total-jobs']+1):
...  try:
...   bs.delete(i)
...   print i
...  except: pass
... 
6
```

I believe the parsed result is identical to what PyYAML gives for the same input, with the exception of the rusage and version keys, which this code leaves as strings. This would affect someone graphing rusage, but not most people.
