### PR TITLE
Update Travis to use Beanstalkd 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
 
 install:
     # Install most recent beanstalkd from source
-    - wget https://github.com/kr/beanstalkd/archive/v1.9.tar.gz
-    - tar xf v1.9.tar.gz
-    - make -C beanstalkd-1.9/
-    - mv beanstalkd-1.9/beanstalkd .
+    - wget https://github.com/kr/beanstalkd/archive/v1.10.tar.gz
+    - tar xf v1.10.tar.gz
+    - make -C beanstalkd-1.10/
+    - mv beanstalkd-1.10/beanstalkd .
     # Install Python dependencies.
     - pip install -r .travis-requirements.txt --use-mirrors
 


### PR DESCRIPTION
Beanstalkd 1.10 was released about a month ago: http://kr.github.io/beanstalkd/2014/08/04/1.10-release-notes.html
